### PR TITLE
Fixes bad value for DJANGO_ALLOWED_HOSTS

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -107,7 +107,7 @@ Keycloak URL
 Django ALLOWED_HOSTS
 */}}
 {{- define "metagrid.django_allowed_hosts" -}}
-{{- join "," (list "$(THIS_POD_IP)" "localhost" .Values.ingress.react.host (printf "%s-django" (include "metagrid.fullname" .))) -}}
+{{- join "," (list "0.0.0.0" "localhost" .Values.ingress.react.host (printf "%s-django" (include "metagrid.fullname" .))) -}}
 {{- end }}
 
 {{/*

--- a/chart/templates/django/deployment.yaml
+++ b/chart/templates/django/deployment.yaml
@@ -46,10 +46,6 @@ spec:
             - name: {{ tpl $key $ }}
               value: {{ tpl $value $ | quote }}
             {{- end }}
-            - name: THIS_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
           ports:
           - name: http
             containerPort: {{ .Values.django.service.port }}


### PR DESCRIPTION
The pods IP was being added to `DJANGO_ALLOWED_HOSTS` using Kubernetes downward API. The environment variable was referencing `$(THIS_POD_IP)` which was having `$` escaped preventing Django from parsing this field.

The fix is to just to add `0.0.0.0` to `DJANGO_ALLOWED_HOSTS`, Kubernetes CNI will handling traffic filtering.