### PR TITLE
Update metagrid to v1.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 chart/charts
 **/.cr-release-packages/**
+.cr-index/
 temp/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: package
+package:
+	helm repo add bitnami https://charts.bitnami.com/bitnami || exit 0
+	cr --config cr.yaml package chart/
+
+.PHONY: upload
+upload:
+	cr --config cr.yaml upload --skip-existing --token $(TOKEN)
+
+.PHONY: index
+index:
+	mkdir .cr-index || exit 0
+	cr --config cr.yaml index --push --token $(TOKEN)
+
+.PHONY: release
+release: package upload index
+
+.PHONY: bump-%
+bump-%:
+	tbump --no-tag $(ARGS) $(shell python -m semver bump $* $(shell tbump current-version))

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,7 +3,7 @@ name: metagrid
 description: A Helm chart for the Metagrid frontend/backend
 type: application
 version: 0.1.4
-appVersion: "v1.1.0"
+appVersion: "1.1.2-pre"
 home: https://github.com/esgf2-us/metagrid-k8s
 sources:
   - https://github.com/aims-group/metagrid

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metagrid
 description: A Helm chart for the Metagrid frontend/backend
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "1.1.2-pre"
 home: https://github.com/esgf2-us/metagrid-k8s
 sources:

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -198,7 +198,7 @@ containers:
   envFrom:
   {{- toYaml . | nindent 4 }}
   {{- end }}
-  image: {{ .image.repository }}:{{ .image.tag }}
+  image: {{ .image.repository }}:{{ default .TemplateValues.Chart.AppVersion .image.tag }}
   {{- with .image.pullPolicy }}
   imagePullPolicy: {{ . }}
   {{- end }}

--- a/chart/templates/react/deployment.yaml
+++ b/chart/templates/react/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- $_ := set $react "env" (mustMerge (default dict $react.env) (dict "SKIP_NGINX_CONF" "true" "DEBUG" "true" "PUBLIC_URL" .Values.react.urlPath)) }}
       {{- $config := dict "configMapRef" (dict "name" (printf "%s-react" (include "metagrid.fullname" .))) }}
       {{- $_ := set $react "envFrom" (list $config) }}
-      {{- $_ := set $react "TemplateValues" (deepCopy .Values) }}
+      {{- $_ := set $react "TemplateValues" . }}
       {{- $_ := set $react.service "name" "http" }}
       {{- $_ := set $react "livenessProbe" (dict "httpGet" (dict "port" "http" "path" .Values.react.urlPath)) }}
       {{- $_ := set $react "readinessProbe" (dict "httpGet" (dict "port" "http" "path" .Values.react.urlPath)) }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -85,7 +85,8 @@ react:
     # -- Container pull policy
     pullPolicy: Always
     # -- Container tag
-    tag: 1.1.2-pre
+    # tag: 1.1.2-pre
+    tag:
 
   nameOverride: ""
   fullnameOverride: ""
@@ -192,7 +193,8 @@ django:
     # -- Image pull policy
     pullPolicy: Always
     # -- Container tag
-    tag: 1.1.2-pre
+    # tag: 1.1.2-pre
+    tag:
 
   nameOverride: ""
   fullnameOverride: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -85,7 +85,7 @@ react:
     # -- Container pull policy
     pullPolicy: Always
     # -- Container tag
-    tag: v1.1.1-pre
+    tag: v1.1.2-rc
 
   nameOverride: ""
   fullnameOverride: ""
@@ -192,7 +192,7 @@ django:
     # -- Image pull policy
     pullPolicy: Always
     # -- Container tag
-    tag: v1.1.1-pre
+    tag: v1.1.2-rc
 
   nameOverride: ""
   fullnameOverride: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -85,7 +85,7 @@ react:
     # -- Container pull policy
     pullPolicy: Always
     # -- Container tag
-    tag: v1.1.2-rc
+    tag: 1.1.2-pre
 
   nameOverride: ""
   fullnameOverride: ""
@@ -192,7 +192,7 @@ django:
     # -- Image pull policy
     pullPolicy: Always
     # -- Container tag
-    tag: v1.1.2-rc
+    tag: 1.1.2-pre
 
   nameOverride: ""
   fullnameOverride: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -36,7 +36,7 @@ esgfNodeStatusUrl:
 solrUrl: https://esgf-node.llnl.gov/solr
 
 # -- Base url for use when using an external TLS termination e.g. https://metagrid.io
-baseUrl:
+baseUrl: https://aims4.llnl.gov/prometheus/api/v1/query?query=probe_success%7Bjob%3D%22http_2xx%22%2C+target%3D~%22.%2Athredds.%2A%22%7D
 
 # -- Customize projects loaded during the initial migration, this is the value stored in [initial_projects_data.py](https://github.com/aims-group/metagrid/blob/master/backend/metagrid/initial_projects_data.py)
 projects:
@@ -69,7 +69,7 @@ react:
   googleAnalyticsID:
 
   # -- Custom url for external metagrid backend
-  backendUrl:
+  backendUrl: http://127.0.0.1:5000
 
   # -- Frontend path prefix
   urlPath: /metagrid

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -85,7 +85,6 @@ react:
     # -- Container pull policy
     pullPolicy: Always
     # -- Container tag
-    # tag: 1.1.2-pre
     tag:
 
   nameOverride: ""
@@ -193,7 +192,6 @@ django:
     # -- Image pull policy
     pullPolicy: Always
     # -- Container tag
-    # tag: 1.1.2-pre
     tag:
 
   nameOverride: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -30,13 +30,13 @@ wgetApiUrl: https://esgf-node.llnl.gov/esg-search/wget
 searchUrl: https://esgf-node.llnl.gov/esg-search/search
 
 # -- ESGF node status url
-esgfNodeStatusUrl:
+esgfNodeStatusUrl: https://aims4.llnl.gov/prometheus/api/v1/query?query=probe_success%7Bjob%3D%22http_2xx%22%2C+target%3D~%22.%2Athredds.%2A%22%7D
 
 # -- (Deprecated) ESGF solr url
 solrUrl: https://esgf-node.llnl.gov/solr
 
 # -- Base url for use when using an external TLS termination e.g. https://metagrid.io
-baseUrl: https://aims4.llnl.gov/prometheus/api/v1/query?query=probe_success%7Bjob%3D%22http_2xx%22%2C+target%3D~%22.%2Athredds.%2A%22%7D
+baseUrl:
 
 # -- Customize projects loaded during the initial migration, this is the value stored in [initial_projects_data.py](https://github.com/aims-group/metagrid/blob/master/backend/metagrid/initial_projects_data.py)
 projects:

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,2 +1,3 @@
+git-repo: metagrid-k8s
 owner: esgf2-us
 skip-existing: true

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/esgf2-us/metagrid-k8s/"
 
 [version]
-current = "0.1.2"
+current = "0.1.4"
 
 regex = '''
   (?P<major>\d+)

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/esgf2-us/metagrid-k8s/"
 
 [version]
-current = "0.1.4"
+current = "0.1.5"
 
 regex = '''
   (?P<major>\d+)


### PR DESCRIPTION
- Updates `appVersion`
- Fixes default container `image:` to default to `Chart.AppVersion`
- Fixes default `backendUrl`
- Removes deepcopy of `.Values` should be `.`
- Removes default `esgfNodeStatusUrl`